### PR TITLE
Making sure that provisioning fails at the first error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ Jenkinsfile*
 id_rsa
 id_rsa.pub
 env.sh
+/haproxy-node 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,11 +26,12 @@ Vagrant.configure(2) do |config|
       ubuntu_ucp_node1.landrush.host 'nodeapp.local', '172.28.128.35'
       ubuntu_ucp_node1.landrush.host 'visualizer.local', '172.28.128.35'
       config.vm.provider :virtualbox do |vb|
-        vb.customize ["modifyvm", :id, "--memory", "2560"]
+        vb.customize ["modifyvm", :id, "--memory", "4096"]
         vb.customize ["modifyvm", :id, "--cpus", "2"]
         vb.name = "ubuntu-ucp-node1"
       end
       ubuntu_ucp_node1.vm.provision "shell", inline: <<-SHELL
+        set -e
         sudo apt-get update
         sudo apt-get install -y apt-transport-https ca-certificates ntpdate jq
         sudo ntpdate -s time.nist.gov
@@ -53,7 +54,7 @@ Vagrant.configure(2) do |config|
         ./create_tokens.sh
         ./backup_ucp.sh
         # ./visualizer.sh
-     SHELL
+      SHELL
     end
 
     # Docker EE manager node for ubuntu 16.04 (optional)
@@ -69,6 +70,7 @@ Vagrant.configure(2) do |config|
         vb.name = "ubuntu-ucp-node2"
       end
       ubuntu_ucp_node2.vm.provision "shell", inline: <<-SHELL
+        set -e
         sudo apt-get update
         sudo apt-get install -y apt-transport-https ca-certificates ntpdate
         sudo ntpdate -s time.nist.gov
@@ -78,7 +80,7 @@ Vagrant.configure(2) do |config|
         sudo chmod +x join_manager.sh
         ./install_ee.sh
         ./join_manager.sh
-      SHELL
+       SHELL
     end
 
     # Docker EE manager node for ubuntu 16.04 (optional)
@@ -94,6 +96,7 @@ Vagrant.configure(2) do |config|
         vb.name = "ubuntu-ucp-node3"
       end
       ubuntu_ucp_node3.vm.provision "shell", inline: <<-SHELL
+        set -e
         sudo apt-get update
         sudo apt-get install -y apt-transport-https ca-certificates ntpdate
         sudo ntpdate -s time.nist.gov
@@ -103,7 +106,7 @@ Vagrant.configure(2) do |config|
         sudo chmod +x join_manager.sh
         ./install_ee.sh
         ./join_manager.sh
-     SHELL
+      SHELL
     end
 
     # Docker EE DTR node for ubuntu 16.04
@@ -120,6 +123,7 @@ Vagrant.configure(2) do |config|
         vb.name = "ubuntu-dtr-node1"
       end
       ubuntu_dtr_node1.vm.provision "shell", inline: <<-SHELL
+        set -e
         sudo apt-get update
         sudo apt-get install -y apt-transport-https ca-certificates ntpdate jq
         sudo ntpdate -s time.nist.gov
@@ -140,7 +144,7 @@ Vagrant.configure(2) do |config|
         ./install_dtr.sh
         ./prepopulate.sh
         ./backup_dtr.sh
-      SHELL
+       SHELL
     end
 
     # Docker EE node for ubuntu 16.04
@@ -156,6 +160,7 @@ Vagrant.configure(2) do |config|
         vb.name = "ubuntu-worker-node1"
       end
       ubuntu_worker_node1.vm.provision "shell", inline: <<-SHELL
+        set -e
         sudo apt-get update
         sudo apt-get install -y apt-transport-https ca-certificates ntpdate
         sudo ntpdate -s time.nist.gov
@@ -165,7 +170,7 @@ Vagrant.configure(2) do |config|
         sudo chmod +x join_worker.sh
         ./install_ee.sh
         ./join_worker.sh
-     SHELL
+      SHELL
     end
 
     # Docker EE node for ubuntu 16.04
@@ -181,6 +186,7 @@ Vagrant.configure(2) do |config|
         vb.name = "ubuntu-worker-node2"
       end
       ubuntu_worker_node2.vm.provision "shell", inline: <<-SHELL
+        set -e
         sudo apt-get update
         sudo apt-get install -y apt-transport-https ca-certificates ntpdate
         sudo ntpdate -s time.nist.gov
@@ -191,7 +197,7 @@ Vagrant.configure(2) do |config|
         sleep 5
         ./install_ee.sh
         ./join_worker.sh
-     SHELL
+      SHELL
     end
 
     # Gitlab node for ubuntu 16.04 (https://docs.gitlab.com/omnibus/docker/)
@@ -207,6 +213,7 @@ Vagrant.configure(2) do |config|
         vb.name = "gitlab-node"
       end
       gitlab_node.vm.provision "shell", inline: <<-SHELL
+        set -e
         sudo apt-get update
         sudo apt-get install -y apt-transport-https ca-certificates ntpdate
         sudo ntpdate -s time.nist.gov
@@ -216,7 +223,7 @@ Vagrant.configure(2) do |config|
         sudo chmod +x configure_gitlab.sh
         sleep 5
         ./gitlab.sh
-     SHELL
+       SHELL
     end
 
     # Jenkins node for ubuntu 16.04
@@ -232,6 +239,7 @@ Vagrant.configure(2) do |config|
         vb.name = "jenkins-node"
       end
       jenkins_node.vm.provision "shell", inline: <<-SHELL
+        set -e
         sudo apt-get update
         sudo apt-get install -y apt-transport-https ca-certificates ntpdate jq unzip
         sudo ntpdate -s time.nist.gov
@@ -245,7 +253,7 @@ Vagrant.configure(2) do |config|
         ./join_worker.sh
         sleep 15
         ./deploy_jenkins.sh
-     SHELL
+       SHELL
     end
 
     # HAProxy for ubuntu 16.04 (only utilized for HA)
@@ -269,19 +277,20 @@ Vagrant.configure(2) do |config|
       haproxy_node.landrush.host 'visualizer.local', '172.28.128.35'
       haproxy_node.landrush.host 'gitlab.local', '172.28.128.31'
       haproxy_node.vm.provision "shell", inline: <<-SHELL
-       sudo apt-get update
-       sudo apt-get install -y apt-transport-https ca-certificates ntpdate
-       sudo ntpdate -s time.nist.gov
-       sudo apt-get install -y software-properties-common
-       sudo add-apt-repository ppa:vbernat/haproxy-1.7
-       sudo apt-get update
-       sudo apt-get install -y haproxy
-       ifconfig enp0s8 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}' > /vagrant/haproxy-node
-       sudo sed -i '/module(load="imudp")/s/^#//g' /etc/rsyslog.conf
-       sudo sed -i '/input(type="imudp" port="514")/s/^#//g' /etc/rsyslog.conf
-       sudo service rsyslog restart
-       sudo cp /vagrant/files/haproxy.cfg /etc/haproxy/haproxy.cfg
-       sudo service haproxy restart
-      SHELL
+        set -e
+        sudo apt-get update
+        sudo apt-get install -y apt-transport-https ca-certificates ntpdate
+        sudo ntpdate -s time.nist.gov
+        sudo apt-get install -y software-properties-common
+        sudo add-apt-repository ppa:vbernat/haproxy-1.7
+        sudo apt-get update
+        sudo apt-get install -y haproxy
+        ifconfig enp0s8 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}' > /vagrant/haproxy-node
+        sudo sed -i '/module(load="imudp")/s/^#//g' /etc/rsyslog.conf
+        sudo sed -i '/input(type="imudp" port="514")/s/^#//g' /etc/rsyslog.conf
+        sudo service rsyslog restart
+        sudo cp /vagrant/files/haproxy.cfg /etc/haproxy/haproxy.cfg
+        sudo service haproxy restart
+       SHELL
     end
 end

--- a/scripts/backup_dtr.sh
+++ b/scripts/backup_dtr.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 export UCP_USERNAME=$(cat /vagrant/env/ucp_username)
 export UCP_PASSWORD=$(cat /vagrant/env/ucp_password)
 export UCP_IPADDR=$(cat /vagrant/env/ucp-node1-ipaddr)

--- a/scripts/backup_ucp.sh
+++ b/scripts/backup_ucp.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 export UCP_ID=$(cat /vagrant/env/ucp-id)
 export UCP_VERSION=3.1.0
 

--- a/scripts/configure_gitlab.sh
+++ b/scripts/configure_gitlab.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Create users
 curl --insecure --request POST --header "PRIVATE-TOKEN: $GITLAB_TOKEN" \
   --header "Content-Type:application/json" https://gitlab.local/api/v3/users \

--- a/scripts/configure_ucp.sh
+++ b/scripts/configure_ucp.sh
@@ -1,3 +1,5 @@
+set -e
+
 export UCP_VERSION=3.1.0
 export UCP_ID=$(cat /vagrant/env/ucp-id)
 

--- a/scripts/create_tokens.sh
+++ b/scripts/create_tokens.sh
@@ -1,2 +1,4 @@
+set -e
+
 docker swarm join-token -q manager > /vagrant/env/swarm-join-token-mgr
 docker swarm join-token -q worker > /vagrant/env/swarm-join-token-worker

--- a/scripts/deploy_jenkins.sh
+++ b/scripts/deploy_jenkins.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 export UCP_IPADDR=$(cat /vagrant/env/ucp-node1-ipaddr)
 export UCP_PASSWORD=$(cat /vagrant/env/ucp_password)
 export UCP_USERNAME=$(cat /vagrant/env/ucp_username)

--- a/scripts/install_dtr.sh
+++ b/scripts/install_dtr.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 < /dev/urandom tr -dc a-f0-9 | head -c${1:-12} > /vagrant/env/dtr-replica-id
 ifconfig enp0s8 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}' > /vagrant/env/dtr-node1-ipaddr
 export UCP_IPADDR=$(cat /vagrant/env/ucp-node1-ipaddr)

--- a/scripts/install_ee.sh
+++ b/scripts/install_ee.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Add additional DNS servers to help resolve storebits.docker.com domain
 sudo sh -c "echo 'nameserver 8.8.8.8
 nameserver 8.8.4.4' >> /etc/resolvconf/resolv.conf.d/base"

--- a/scripts/install_notary.sh
+++ b/scripts/install_notary.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 sudo apt-get install -y unzip jq
 
 export UCP_IPADDR=$(cat /vagrant/env/ucp-node1-ipaddr)

--- a/scripts/install_ucp.sh
+++ b/scripts/install_ucp.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e
+
 export UCP_VERSION=3.1.0
 
 ifconfig enp0s8 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}' > /vagrant/env/ucp-node1-ipaddr

--- a/scripts/join_manager.sh
+++ b/scripts/join_manager.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 export UCP_IPADDR=$(cat /vagrant/env/ucp-node1-ipaddr)
 export SWARM_JOIN_TOKEN_MASTER=$(cat /vagrant/env/swarm-join-token-mgr)
 docker swarm join --token ${SWARM_JOIN_TOKEN_MASTER} ${UCP_IPADDR}:2377

--- a/scripts/join_worker.sh
+++ b/scripts/join_worker.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 export UCP_IPADDR=$(cat /vagrant/env/ucp-node1-ipaddr)
 export SWARM_JOIN_TOKEN_WORKER=$(cat /vagrant/env/swarm-join-token-worker)
 docker swarm join --token ${SWARM_JOIN_TOKEN_WORKER} ${UCP_IPADDR}:2377

--- a/scripts/prepopulate.sh
+++ b/scripts/prepopulate.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 export UCP_IPADDR=$(cat /vagrant/env/ucp-node1-ipaddr)
 export UCP_USERNAME=$(cat /vagrant/env/ucp_username)
 export UCP_PASSWORD=$(cat /vagrant/env/ucp_password)

--- a/scripts/restore_dtr.sh
+++ b/scripts/restore_dtr.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 export UCP_IPADDR=$(cat /vagrant/env/ucp-node1-ipaddr)
 export DTR_IPADDR=$(cat /vagrant/env/dtr-node1-ipaddr)
 export UCP_PASSWORD=$(cat /vagrant/env/ucp_password)

--- a/scripts/restore_ucp.sh
+++ b/scripts/restore_ucp.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 export UCP_IPADDR=$(cat /vagrant/env/ucp-node1-ipaddr)
 export UCP_PASSWORD=$(cat /vagrant/env/ucp_password)
 export UCP_ID=$(cat /vagrant/env/ucp-id)

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 vagrant snapshot restore ucp
 vagrant snapshot restore dtr
 vagrant snapshot restore worker-node1

--- a/scripts/snapshot.sh
+++ b/scripts/snapshot.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 vagrant snapshot push ucp
 vagrant snapshot push dtr
 vagrant snapshot push worker-node1

--- a/scripts/trust_dtr.sh
+++ b/scripts/trust_dtr.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
+set -e
+
 openssl s_client -connect ${DTR_IPADDR}:443 -showcerts </dev/null 2>/dev/null | openssl x509 -outform PEM | sudo tee /usr/local/share/ca-certificates/${DTR_IPADDR}.crt
 sudo update-ca-certificates

--- a/scripts/upgrade_dtr.sh
+++ b/scripts/upgrade_dtr.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 export DTR_VERSION=2.6.0
 export UCP_IPADDR=$(cat /vagrant/env/ucp-vancouver-node1-ipaddr)
 export UCP_PASSWORD=$(cat /vagrant/env/ucp_password)

--- a/scripts/visualizer.sh
+++ b/scripts/visualizer.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 docker network create -d overlay visualizer
 
 docker service create -d \


### PR DESCRIPTION
It's better to fail early when provisioning: the error is immediately
obvious to the user, and not buried under a pile of subsequent logging
and downstream errors.

Also giving more RAM to the UCP box, seems it needs it :)